### PR TITLE
Switched to SSL-compatible URLs for style

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -11,9 +11,9 @@
     <link rel="stylesheet" type="text/css" href="//cloud.webtype.com/css/944a7551-9b08-4f0a-8767-e0f83db4a16b.css" />
 
     <!-- The light version of the main CFA stylesheet -->
-  <link rel="stylesheet" href="//style.codeforamerica.org/style/css/cfa-light.css">
+  <link rel="stylesheet" href="//style.codeforamerica.org/1/style/css/cfa-light.css">
 
-  <link rel="stylesheet" href="//style.codeforamerica.org/style/css/layout.css" media="all and (min-width: 40em)">
+  <link rel="stylesheet" href="//style.codeforamerica.org/1/style/css/layout.css" media="all and (min-width: 40em)">
 
   <!--[if lt IE 9]>
       <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
@@ -24,13 +24,13 @@
   <![endif]-->
 
   <!-- (Optional) A plugin that adds syntax highlighting to code samples -->
-  <link href="//style.codeforamerica.org/style/css/prism.css" rel="stylesheet" />
+  <link href="//style.codeforamerica.org/1/style/css/prism.css" rel="stylesheet" />
 
   <!-- Link to a 32x32 favicon -->
   <link rel="shortcut icon" type="image/x-icon" href="//style.codeforamerica.org/favicon.ico">
 
   <!-- (Optional) Link to a 60x60 bookmark icon for iOS -->
-  <link rel="apple-touch-icon-precomposed" href="//style.codeforamerica.org/style/favicons/60x60/flag-red.png"/>
+  <link rel="apple-touch-icon-precomposed" href="//style.codeforamerica.org/1/style/favicons/60x60/flag-red.png"/>
 
   <!-- App-specific stylesheet -->
   <link rel="stylesheet" href="/css/custom.css">


### PR DESCRIPTION
This should work with https://style.codeforamerica.org, but test please first.
