### PR TITLE
[WIP] Create and connect to Twilio phone number

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'sinatra'
 gem 'httparty'
 gem 'redis'
 gem 'twilio-ruby'
+gem 'sendgrid-ruby'
 
 group :test, :development do
   gem 'rspec'

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby '2.1.1'
 gem 'sinatra'
 gem 'httparty'
 gem 'redis'
+gem 'twilio-ruby'
 
 group :test, :development do
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,18 +4,24 @@ GEM
     builder (3.2.2)
     coderay (1.1.0)
     diff-lcs (1.2.5)
+    domain_name (0.5.24)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (0.10.0)
     foreman (0.63.0)
       dotenv (>= 0.7)
       thor (>= 0.13.6)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     httparty (0.13.1)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     json (1.8.1)
     jwt (1.0.0)
     method_source (0.8.2)
+    mime-types (2.5)
     multi_json (1.10.1)
     multi_xml (0.5.5)
+    netrc (0.10.3)
     pry (0.9.12.6)
       coderay (~> 1.0)
       method_source (~> 0.8)
@@ -26,6 +32,10 @@ GEM
     rack-test (0.6.2)
       rack (>= 1.0)
     redis (3.1.0)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     rspec (3.0.0)
       rspec-core (~> 3.0.0)
       rspec-expectations (~> 3.0.0)
@@ -38,17 +48,24 @@ GEM
     rspec-mocks (3.0.0)
       rspec-support (~> 3.0.0)
     rspec-support (3.0.0)
+    sendgrid-ruby (0.0.3)
+      rest-client
+      smtpapi
     sinatra (1.4.5)
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
     slop (3.5.0)
+    smtpapi (0.1.0)
     thor (0.19.1)
     tilt (1.4.1)
     twilio-ruby (3.13.1)
       builder (>= 2.1.2)
       jwt (~> 1.0.0)
       multi_json (>= 1.3.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
 
 PLATFORMS
   ruby
@@ -61,5 +78,6 @@ DEPENDENCIES
   rack-test
   redis
   rspec
+  sendgrid-ruby
   sinatra
   twilio-ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    builder (3.2.2)
     coderay (1.1.0)
     diff-lcs (1.2.5)
     dotenv (0.10.0)
@@ -11,7 +12,9 @@ GEM
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     json (1.8.1)
+    jwt (1.0.0)
     method_source (0.8.2)
+    multi_json (1.10.1)
     multi_xml (0.5.5)
     pry (0.9.12.6)
       coderay (~> 1.0)
@@ -42,6 +45,10 @@ GEM
     slop (3.5.0)
     thor (0.19.1)
     tilt (1.4.1)
+    twilio-ruby (3.13.1)
+      builder (>= 2.1.2)
+      jwt (~> 1.0.0)
+      multi_json (>= 1.3.0)
 
 PLATFORMS
   ruby
@@ -55,3 +62,4 @@ DEPENDENCIES
   redis
   rspec
   sinatra
+  twilio-ruby

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@
 - Set `REDISTOGO_URL` to redis://localhost:6379 (or whatever your local connection is)
 - Run the app with `bundle exec rackup` and open your browser to http://localhost:9292
 
+## Testing
+
+Test the builder with [RSpec](http://rspec.info) and a few fake environment variables:
+
+    env HEROKU_OAUTH_ID=- HEROKU_OAUTH_SECRET=- REDISTOGO_URL=- \
+        rspec spec/lib/cityvoice_twilio_service_spec.rb
+
 ## Deployment
 
 Non-CFA users shouldn't need to deploy this, but for documentation purposes, here goes!

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@
 
 Test the builder with [RSpec](http://rspec.info) and a few fake environment variables:
 
-    env HEROKU_OAUTH_ID=- HEROKU_OAUTH_SECRET=- REDISTOGO_URL=- \
-        rspec spec/lib/cityvoice_twilio_service_spec.rb
+    env HEROKU_OAUTH_ID=- HEROKU_OAUTH_SECRET=- REDISTOGO_URL=- rspec spec
 
 ## Deployment
 

--- a/cityvoice_builder_heroku.rb
+++ b/cityvoice_builder_heroku.rb
@@ -176,7 +176,7 @@ class CityvoiceBuilderHeroku < Sinatra::Base
     questions = JSON.parse(redis.get("#{params[:user_token]}_questions"))
     twilio_sid, twilio_token = ENV['TWILIO_ACCOUNT_SID'], ENV['TWILIO_AUTH_TOKEN']
     phone_number = CityvoiceTwilioService.new(twilio_sid, twilio_token)
-                                         .buy_number_by_location(locations)
+                                         .buy_number_by_locations(locations)
     app_content_set_csv_string = CityvoiceCsvGenerator.app_content_set_csv(phone_number)
     locations_csv_string = CityvoiceCsvGenerator.locations_csv(locations)
     questions_csv_string = CityvoiceCsvGenerator.questions_csv(questions)

--- a/cityvoice_builder_heroku.rb
+++ b/cityvoice_builder_heroku.rb
@@ -239,7 +239,7 @@ class CityvoiceBuilderHeroku < Sinatra::Base
   #
   #   https://github.com/codeforamerica/cityvoice-survey-builder/issues/61#issuecomment-97584397
   #
-  # After user selects a phone number, reserve it with Heroku:
+  # After user selects a phone number, reserve it with Twilio:
   #
   #   https://github.com/codeforamerica/cityvoice-survey-builder/issues/61#issuecomment-97588226
   #

--- a/cityvoice_builder_heroku.rb
+++ b/cityvoice_builder_heroku.rb
@@ -42,6 +42,12 @@ class CityvoiceBuilderHeroku < Sinatra::Base
   get '/' do
     erb :index
   end
+  
+  #
+  # Do we need the signup page any longer, if we're not asking people to set
+  # up their own Twilio accounts and Heroku does a good job of stepping people
+  # through account creation and return upon OAuth?
+  #
 
   get '/signup' do
     @page_name = 'signup'

--- a/cityvoice_builder_heroku.rb
+++ b/cityvoice_builder_heroku.rb
@@ -172,7 +172,9 @@ class CityvoiceBuilderHeroku < Sinatra::Base
     # Parse JSON from Redis into Ruby hashes
     locations = JSON.parse(redis.get("#{params[:user_token]}_locations"))
     questions = JSON.parse(redis.get("#{params[:user_token]}_questions"))
-    phone_number = CityvoiceTwilioService.buy_number_by_location(locations)
+    twilio_sid, twilio_token = ENV['TWILIO_ACCOUNT_SID'], ENV['TWILIO_AUTH_TOKEN']
+    phone_number = CityvoiceTwilioService.new(twilio_sid, twilio_token)
+                                         .buy_number_by_location(locations)
     app_content_set_csv_string = CityvoiceCsvGenerator.app_content_set_csv(phone_number)
     locations_csv_string = CityvoiceCsvGenerator.locations_csv(locations)
     questions_csv_string = CityvoiceCsvGenerator.questions_csv(questions)

--- a/cityvoice_builder_heroku.rb
+++ b/cityvoice_builder_heroku.rb
@@ -4,7 +4,9 @@ require 'json'
 require 'redis'
 require 'securerandom'
 require 'fileutils'
+require 'twilio-ruby'
 require File.expand_path('../lib/cityvoice_csv_generator', __FILE__)
+require File.expand_path('../lib/cityvoice_twilio_service', __FILE__)
 
 class CityvoiceBuilderHeroku < Sinatra::Base
   raise "Need to set HEROKU_OAUTH_ID" unless ENV.has_key?('HEROKU_OAUTH_ID')

--- a/cityvoice_builder_heroku.rb
+++ b/cityvoice_builder_heroku.rb
@@ -228,6 +228,23 @@ class CityvoiceBuilderHeroku < Sinatra::Base
     redis.expire("#{token}_tarball", settings.expiration_time)
     redirect to("/#{params[:user_token]}/push"), 302
   end
+  
+  #
+  # After locations, questions, and audio, but before
+  # pushing build to Heroku, add phone number selection.
+  #
+  # Use average lat/lon and IncomingPhoneNumbers to find local numbers,
+  # and display a list for people to choose from. They may have feelings
+  # about the right area code to use:
+  #
+  #   https://github.com/codeforamerica/cityvoice-survey-builder/issues/61#issuecomment-97584397
+  #
+  # After user selects a phone number, reserve it with Heroku:
+  #
+  #   https://github.com/codeforamerica/cityvoice-survey-builder/issues/61#issuecomment-97588226
+  #
+  # Include the phone number in the tarball, if Dave is to be believed.
+  #
 
   get '/:user_token/push' do
     @heroku_authorize_url = "https://id.heroku.com/oauth/authorize?" \
@@ -263,6 +280,19 @@ class CityvoiceBuilderHeroku < Sinatra::Base
     end
     erb :response
   end
+
+  #
+  # After Heroku authorization add phone number configuration
+  # and email to CfA about new signups.
+  #
+  # Use the generated app name to create a voice callback URL and inform Twilio:
+  #
+  #   https://github.com/codeforamerica/cityvoice-survey-builder/issues/61#issuecomment-97589478
+  #
+  # Use Heroku account information to inform CfA:
+  #
+  #   https://github.com/codeforamerica/cityvoice-survey-builder/issues/61#issuecomment-97606058
+  #
 
   get '/sign' do
     puts params

--- a/cityvoice_builder_heroku.rb
+++ b/cityvoice_builder_heroku.rb
@@ -5,6 +5,7 @@ require 'redis'
 require 'securerandom'
 require 'fileutils'
 require 'twilio-ruby'
+require 'sendgrid-ruby'
 require File.expand_path('../lib/cityvoice_csv_generator', __FILE__)
 require File.expand_path('../lib/cityvoice_twilio_service', __FILE__)
 
@@ -299,6 +300,20 @@ class CityvoiceBuilderHeroku < Sinatra::Base
 
     CityvoiceTwilioService.new(twilio_sid, twilio_token)
                                .set_number_voice_url(number_sid, voice_url)
+    
+    client = SendGrid::Client.new(api_user: ENV['SENDGRID_USERNAME'], api_key: ENV['SENDGRID_PASSWORD'])
+    puts ENV['SENDGRID_USERNAME']
+    puts ENV['SENDGRID_PASSWORD']
+    mail = SendGrid::Mail.new(
+      to: 'mike@codeforamerica.org',
+      from: 'mike@codeforamerica.org',
+      subject: 'Yo, CityVoice Roolz',
+      text: <<-EOF
+        America FUCK YEAH there's a new kid on the block at #{@built_app_url}
+        EOF
+    )
+    
+    puts client.send(mail)
     
     erb :response
   end

--- a/cityvoice_builder_heroku.rb
+++ b/cityvoice_builder_heroku.rb
@@ -175,9 +175,10 @@ class CityvoiceBuilderHeroku < Sinatra::Base
     locations = JSON.parse(redis.get("#{params[:user_token]}_locations"))
     questions = JSON.parse(redis.get("#{params[:user_token]}_questions"))
     twilio_sid, twilio_token = ENV['TWILIO_ACCOUNT_SID'], ENV['TWILIO_AUTH_TOKEN']
-    phone_number = CityvoiceTwilioService.new(twilio_sid, twilio_token)
-                                         .buy_number_by_locations(locations)
-    app_content_set_csv_string = CityvoiceCsvGenerator.app_content_set_csv(phone_number)
+    number = CityvoiceTwilioService.new(twilio_sid, twilio_token)
+                                   .buy_number_by_locations(locations)
+    redis.set("#{params[:user_token]}_number_sid", number.sid)
+    app_content_set_csv_string = CityvoiceCsvGenerator.app_content_set_csv(number.friendly_name)
     locations_csv_string = CityvoiceCsvGenerator.locations_csv(locations)
     questions_csv_string = CityvoiceCsvGenerator.questions_csv(questions)
     # Download latest CityVoice Tarball from GitHub to /tmp

--- a/cityvoice_builder_heroku.rb
+++ b/cityvoice_builder_heroku.rb
@@ -42,12 +42,6 @@ class CityvoiceBuilderHeroku < Sinatra::Base
   get '/' do
     erb :index
   end
-  
-  #
-  # Do we need the signup page any longer, if we're not asking people to set
-  # up their own Twilio accounts and Heroku does a good job of stepping people
-  # through account creation and return upon OAuth?
-  #
 
   get '/signup' do
     @page_name = 'signup'

--- a/cityvoice_builder_heroku.rb
+++ b/cityvoice_builder_heroku.rb
@@ -290,6 +290,16 @@ class CityvoiceBuilderHeroku < Sinatra::Base
         @built_app_url = "https://#{parsed_response["app"]["name"]}.herokuapp.com"
       end
     end
+    
+    # Add app voice URL to phone number
+    redis = Redis.new(:url => settings.redis_url)
+    number_sid = redis.get("#{params[:state]}_number_sid")
+    voice_url = "#{@built_app_url}/calls"
+    twilio_sid, twilio_token = ENV['TWILIO_ACCOUNT_SID'], ENV['TWILIO_AUTH_TOKEN']
+
+    CityvoiceTwilioService.new(twilio_sid, twilio_token)
+                               .set_number_voice_url(number_sid, voice_url)
+    
     erb :response
   end
 

--- a/lib/cityvoice_csv_generator.rb
+++ b/lib/cityvoice_csv_generator.rb
@@ -19,4 +19,12 @@ module CityvoiceCsvGenerator
     end
     csv_string
   end
+
+  def self.app_content_set_csv(phone_number)
+    csv_string = CSV.generate do |csv|
+      csv << ["Issue", "App Phone Number", "Message From", "Message URL", "Header Color", "Short Title", "Call In Code Digits", "Feedback Form URL"]
+      csv << ["CityVoice", phone_number, "CityVoice Maintainers", "/assets/welcome.mp3", "#6DC6AD", "CityVoice", "3", "http://example.com"]
+    end
+    csv_string
+  end
 end

--- a/lib/cityvoice_twilio_service.rb
+++ b/lib/cityvoice_twilio_service.rb
@@ -37,4 +37,14 @@ class CityvoiceTwilioService
     # Return a string like "(510) 555-1212"
     return bought
   end
+  
+  def set_number_voice_url(number_sid, voice_url)
+    #
+    # Use the generated app name to create a voice callback URL and inform Twilio:
+    #
+    #   https://github.com/codeforamerica/cityvoice-survey-builder/issues/61#issuecomment-97589478
+    #
+    number = @client.account.incoming_phone_numbers.get(number_sid)
+    number.update({:voice_url => voice_url})
+  end
 end

--- a/lib/cityvoice_twilio_service.rb
+++ b/lib/cityvoice_twilio_service.rb
@@ -27,7 +27,7 @@ class CityvoiceTwilioService
     #   https://github.com/codeforamerica/cityvoice-survey-builder/issues/61#issuecomment-97588226
     #
     numbers = @client.available_phone_numbers.get('US').local.list(
-      near_lat_long: "#{lat},#{lng}",
+      near_lat_long: sprintf( "%0.5f,%0.5f", lat, lng),
       distance: 50
     )
     

--- a/lib/cityvoice_twilio_service.rb
+++ b/lib/cityvoice_twilio_service.rb
@@ -4,7 +4,7 @@ class CityvoiceTwilioService
     @client = Twilio::REST::Client.new(account_sid, auth_token)
   end
 
-  def buy_number_by_location(locations)
+  def buy_number_by_locations(locations)
     #
     # Calculate average location.
     #

--- a/lib/cityvoice_twilio_service.rb
+++ b/lib/cityvoice_twilio_service.rb
@@ -35,6 +35,6 @@ class CityvoiceTwilioService
     bought = @client.account.incoming_phone_numbers.create(:phone_number => wanted.phone_number)
     
     # Return a string like "(510) 555-1212"
-    return bought.friendly_name
+    return bought
   end
 end

--- a/lib/cityvoice_twilio_service.rb
+++ b/lib/cityvoice_twilio_service.rb
@@ -1,0 +1,40 @@
+class CityvoiceTwilioService
+
+  def initialize(account_sid, auth_token)
+    @client = Twilio::REST::Client.new(account_sid, auth_token)
+  end
+
+  def buy_number_by_location(locations)
+    #
+    # Calculate average location.
+    #
+    lat, lng = 0, 0
+
+    locations.each do |loc|
+      lat += loc["lat"].to_f / locations.count
+      lng += loc["lng"].to_f / locations.count
+    end
+    
+    #
+    # Use average lat/lon and IncomingPhoneNumbers to find local numbers,
+    # and display a list for people to choose from. They may have feelings
+    # about the right area code to use:
+    #
+    #   https://github.com/codeforamerica/cityvoice-survey-builder/issues/61#issuecomment-97584397
+    #
+    # After user selects a phone number, reserve it with Twilio:
+    #
+    #   https://github.com/codeforamerica/cityvoice-survey-builder/issues/61#issuecomment-97588226
+    #
+    numbers = @client.available_phone_numbers.get('US').local.list(
+      near_lat_long: "#{lat},#{lng}",
+      distance: 50
+    )
+    
+    wanted = numbers.first
+    bought = @client.account.incoming_phone_numbers.create(:phone_number => wanted.phone_number)
+    
+    # Return a string like "(510) 555-1212"
+    return bought.friendly_name
+  end
+end

--- a/spec/lib/cityvoice_csv_generator_spec.rb
+++ b/spec/lib/cityvoice_csv_generator_spec.rb
@@ -29,4 +29,17 @@ EOF
       expect(new_csv).to eq(desired_csv_string)
     end
   end
+
+  describe '::app_content_set_csv' do
+    let(:phone_number) { "(510) 555-1212" }
+
+    it 'creates a CSV string in CityVoice format' do
+      new_csv = CityvoiceCsvGenerator.app_content_set_csv(phone_number)
+      desired_csv_string = <<EOF
+Issue,App Phone Number,Message From,Message URL,Header Color,Short Title,Call In Code Digits,Feedback Form URL
+CityVoice,#{phone_number},CityVoice Maintainers,/assets/welcome.mp3,#6DC6AD,CityVoice,3,http://example.com
+EOF
+      expect(new_csv).to eq(desired_csv_string)
+    end
+  end
 end

--- a/spec/lib/cityvoice_twilio_service_spec.rb
+++ b/spec/lib/cityvoice_twilio_service_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe CityvoiceTwilioService do
   let(:fake_client) { double('Twilio::REST::Client') }
-  let(:fake_number) { double('number', :friendly_name => '(222) 333-4444', :phone_number => '+12223334444') }
+  let(:fake_number) { double('number', :friendly_name => '(222) 333-4444', :phone_number => '+12223334444', :sid => '0xDEADBEEF') }
   let(:fake_local_resource) { double('local', :list => [fake_number]) }
   let(:fake_incoming_number_resource) { double('incoming_numbers', :create => fake_number) }
 
@@ -39,7 +39,7 @@ describe CityvoiceTwilioService do
       end
 
       it 'should get a nearby phone number for some location' do
-        expect(@result).to eq(fake_number.friendly_name)
+        expect(@result).to eq(fake_number)
       end
     end
   end

--- a/spec/lib/cityvoice_twilio_service_spec.rb
+++ b/spec/lib/cityvoice_twilio_service_spec.rb
@@ -24,12 +24,12 @@ describe CityvoiceTwilioService do
       }
 
       before do
-        CityvoiceTwilioService.new("sid","token").buy_number_by_locations(location_input)
+        @result = CityvoiceTwilioService.new("sid","token").buy_number_by_locations(location_input)
       end
 
       it 'sends the average of locations to the Twilio client' do
         expect(fake_local_resource).to have_received(:list).with(
-          near_lat_long: "37.8055,-122.26785",
+          near_lat_long: "37.805499999999995,-122.26785",
           distance: 50
         )
       end
@@ -38,8 +38,8 @@ describe CityvoiceTwilioService do
         expect(fake_incoming_number_resource).to have_received(:create).with(phone_number: fake_number.phone_number)
       end
 
-      pending
       it 'should get a nearby phone number for some location' do
+        expect(@result).to eq(fake_number.friendly_name)
       end
     end
   end

--- a/spec/lib/cityvoice_twilio_service_spec.rb
+++ b/spec/lib/cityvoice_twilio_service_spec.rb
@@ -29,7 +29,7 @@ describe CityvoiceTwilioService do
 
       it 'sends the average of locations to the Twilio client' do
         expect(fake_local_resource).to have_received(:list).with(
-          near_lat_long: "37.805499999999995,-122.26785",
+          near_lat_long: "37.80550,-122.26785",
           distance: 50
         )
       end

--- a/spec/lib/cityvoice_twilio_service_spec.rb
+++ b/spec/lib/cityvoice_twilio_service_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe CityvoiceTwilioService do
+  let(:fake_client) { double('Twilio::REST::Client') }
+
+  before do
+    allow(Twilio::REST::Client).to receive(:new).and_return(fake_client)
+    allow(fake_client).to receive_chain(:available_phone_numbers, :get, :local, :list)
+  end
+  
+  describe '#buy_number_by_location' do
+    context 'a set of locations with either float or string values' do    
+      let(:location_input) {
+        [
+          { 'lat' => 37.8129, 'lng' => -122.2742 },
+          { 'lat' => '37.7981', 'lng' => '-122.2615' }
+        ]
+      }
+      
+      before do
+        result = CityvoiceTwilioService.new("sid","token").buy_number_by_locations(location_input)
+      end
+    
+      it 'sends the average of locations to the Twilio client' do
+        expect(fake_client).to receive_chain('available_phone_numbers.get.local.list').with(
+          near_lat_long: "37.8055,-122.26785",
+          distance: 50
+        )
+      end
+      
+      pending
+      it 'should get a nearby phone number for some location' do
+      end
+    end
+  end
+end

--- a/spec/lib/cityvoice_twilio_service_spec.rb
+++ b/spec/lib/cityvoice_twilio_service_spec.rb
@@ -2,32 +2,42 @@ require 'spec_helper'
 
 describe CityvoiceTwilioService do
   let(:fake_client) { double('Twilio::REST::Client') }
+  let(:fake_number) { double('number', :friendly_name => '(222) 333-4444', :phone_number => '+12223334444') }
+  let(:fake_local_resource) { double('local', :list => [fake_number]) }
+  let(:fake_incoming_number_resource) { double('incoming_numbers', :create => fake_number) }
 
   before do
     allow(Twilio::REST::Client).to receive(:new).and_return(fake_client)
-    allow(fake_client).to receive_chain(:available_phone_numbers, :get, :local, :list)
+    allow(fake_client).to receive_message_chain(:available_phone_numbers, :get, :local)
+      .and_return(fake_local_resource)
+    allow(fake_client).to receive_message_chain(:account, :incoming_phone_numbers)
+      .and_return(fake_incoming_number_resource)
   end
-  
+
   describe '#buy_number_by_location' do
-    context 'a set of locations with either float or string values' do    
+    context 'a set of locations with either float or string values' do
       let(:location_input) {
         [
           { 'lat' => 37.8129, 'lng' => -122.2742 },
           { 'lat' => '37.7981', 'lng' => '-122.2615' }
         ]
       }
-      
+
       before do
-        result = CityvoiceTwilioService.new("sid","token").buy_number_by_locations(location_input)
+        CityvoiceTwilioService.new("sid","token").buy_number_by_locations(location_input)
       end
-    
+
       it 'sends the average of locations to the Twilio client' do
-        expect(fake_client).to receive_chain('available_phone_numbers.get.local.list').with(
+        expect(fake_local_resource).to have_received(:list).with(
           near_lat_long: "37.8055,-122.26785",
           distance: 50
         )
       end
-      
+
+      it 'purchases the first available number' do
+        expect(fake_incoming_number_resource).to have_received(:create).with(phone_number: fake_number.phone_number)
+      end
+
       pending
       it 'should get a nearby phone number for some location' do
       end

--- a/views/signup.erb
+++ b/views/signup.erb
@@ -1,21 +1,13 @@
 <h2>Create accounts</h2>
 
-<p>To create a survey, you'll need two <strong>free</strong> accounts from the services that power CityVoice.</p>
-<p>If you already have accounts with these services, skip to the next step, otherwise:</p>
+<p>To create a survey, you'll need a <strong>free</strong> account from a service that powers CityVoice.</p>
+<p>If you already have an account with this service, skip to the next step, otherwise:</p>
 
 <ol>
   <li><h3>Heroku</h3>
     <ul>
       <li><a href="https://signup.heroku.com/www-home-top" target="_blank">Create an account</a> (opens in a new tab).</li>
       <li>When you've confirmed your email address and successfully logged in, return to this page.</p>
-    </ul>
-  </li>
-  <li><h3>Twilio</h3>
-    <ul>
-      <li><a href="https://www.twilio.com/try-twilio" target="_blank">Create an account </a> (opens in a new tab).</li>
-      <li>Fill out the sign-up form and follow the instructions for verifying your account.</li>
-      <li>When you are given your new Twilio phone number, click "<strong>Get Started</strong>" and return to this page (see example below).
-      <img src="/img/twilio-first-phone-number.png" style="border: solid; display: block; margin-left: auto; margin-right: auto;margin-top:10px">
     </ul>
   </li>
 </ol>


### PR DESCRIPTION
* [x] Determine where to inject code for reserving a phone number.
* [x] Designate a Twilio sub-account to hold the numbers.
* [x] Use average lat/lon and IncomingPhoneNumbers to find local numbers, display a list for people to choose from.
* [x] Reserve chosen phone number with Twilio.
* [x] Use the generated app name to create a voice callback URL for Twilio.
* [x] Use Heroku account information to inform CfA of new Cityvoice instance.

Closes #61.